### PR TITLE
Bug fixes in example code and .c file

### DIFF
--- a/FX29K.cpp
+++ b/FX29K.cpp
@@ -169,8 +169,8 @@ void FX29K::write(TwoWire* i2cPtr, uint8_t i2cAddr, uint8_t* arr, uint8_t byteCo
 */
 void FX29K::read(TwoWire* i2cPtr, uint8_t i2cAddr, uint8_t* arr, uint8_t byteCount) {
   i2cPtr->requestFrom(i2cAddr, byteCount);
-  for (uint8_t i = 0; i < byteCount; i++) {
-    *(arr + i) = i2cPtr->read();
+  while (Wire.available()){
+    *(arr) = i2cPtr->read();
+    *arr++;
   }
-  i2cPtr->endTransmission();
 }

--- a/FX29K_for_Arduino.ino
+++ b/FX29K_for_Arduino.ino
@@ -4,6 +4,7 @@ FX29K scale(FX29K0, 0010, &Wire);
 
 void setup(){
   Serial.begin(115200);
+  Wire.begin();
   scale.tare(1000);
   Serial.println("Grams\tPounds\tRaw");
   Serial.println("--------------------");

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FX29K_for_Arduino
-An Arduino library for the FX29K digital load cells.
+An Arduino library for the FX29K digital load cells. But now it works
 
 ## Compatibility
 Supported models:


### PR DESCRIPTION
The example code was missing initialization of the I2C line, and the `read()` function from the library didn't work.
I encountered a forum post where someone else also could not get the library to work properly but I didn't see any fixes. For some reason replacing the for loop with a `while(Wire.available())` loop fixed the problem and the code works. 

I'm using a FX29K0-100A-0100-L and can confirm it is also working on this part number.